### PR TITLE
Fix Critical Crash Bug

### DIFF
--- a/CPSlider/CPSlider.m
+++ b/CPSlider/CPSlider.m
@@ -250,7 +250,7 @@
     }
     
     return [self.scrubbingSpeedPositions indexOfObjectWithOptions:NSEnumerationReverse passingTest:^BOOL(NSNumber *obj, NSUInteger idx, BOOL *stop){
-        if (downrange >= [obj floatValue]) {
+        if (abs(downrange) >= abs([obj floatValue])) {
             return YES;
         }
         return NO;


### PR DESCRIPTION
Fixes crash which occurs sometimes when sliding really quickly and `ignoreDraggingAboveSlider` is set to NO